### PR TITLE
Fix panic when input file is missing or has no extension

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,9 @@ pub fn main() -> Result<(), v2f::Error> {
 		v2f::util::save_memh_file(output_file, program_i32)?;
 		return Ok(());
 	}
-	match if args.input_file.as_ref().unwrap().extension().unwrap() == "lua" {
+	let input_file = args.input_file.ok_or(v2f::Error::NoSuchFile)?;
+	let is_lua = input_file.extension().map_or(false, |ext| ext == "lua");
+	match if is_lua {
 		lua_flow(args)
 	} else {
 		mapped_flow(args)


### PR DESCRIPTION
## Problem
The code in `src/main.rs` line 51 used `.unwrap()` twice when checking the input file extension:

```rust
match if args.input_file.as_ref().unwrap().extension().unwrap() == "lua" {
```

This could cause a panic in two scenarios:
1. When `input_file` is `None` - should return `Error::NoSuchFile` instead
2. When the file has no extension (e.g., `Makefile`, `README`, or any file without `.`) - should handle gracefully

## Solution
Replace the double `unwrap()` with proper error handling:

```rust
let input_file = args.input_file.ok_or(v2f::Error::NoSuchFile)?;
let is_lua = input_file.extension().map_or(false, |ext| ext == "lua");
match if is_lua {
```

This ensures:
- Missing input files return a proper error instead of panicking
- Files without extensions are treated as non-Lua files (defaults to JSON flow)

## Testing
- The fix follows the same pattern already used in the `convert_to_memh` flow (line 44)
- Using `ok_or()` and `map_or()` are idiomatic Rust error handling patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)